### PR TITLE
chore: add Makefile for build and management tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# vim:noet
+ifeq ($(shell uname),Linux)
+	OS=linux
+else
+	OS=darwin
+endif
+
+ifeq ($(shell uname -m),aarch64)
+    ARCH=arm64
+else ifeq ($(shell uname -m),arm64)
+    ARCH=arm64
+else
+    ARCH=amd64
+endif
+
+GITHASH=$(shell git rev-parse HEAD)
+VERSION=$(shell git describe --tags --always)
+LDFLAGS=-ldflags "-w -s -extldflags=-static -X main.Version=${VERSION} -X main.GitHash=${GITHASH} -X main.Built=$(shell date +%s)"
+
+default:
+	make clean
+	make build
+
+.PHONY: install
+install:
+	go mod tidy
+
+.PHONY: build
+build:
+	@env CGO_ENABLED=0 go build ${LDFLAGS} -o bin/tavern main.go
+
+.PHONY: run
+run:
+	@env CGO_ENABLED=0 go run ${LDFLAGS} main.go -c config.yaml
+
+.PHONY: clean
+clean:
+	@rm -rf bin/*
+
+.PHONY: check
+check:
+	@go vet ./...
+	@staticcheck ./...
+
+.PHONY: tools
+tools:
+	@go env -w GOPROXY=https://goproxy.cn,direct
+	@go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
This pull request introduces a new `Makefile` to the project, providing standardized commands for building, running, cleaning, and checking the codebase. The `Makefile` also handles platform and architecture detection, sets up build metadata, and includes tooling support for static analysis.

Build and environment setup:

* Added OS and architecture detection to set appropriate build variables for Linux, Darwin (macOS), and ARM/x86 architectures.
* Defined build metadata variables (`GITHASH`, `VERSION`, `LDFLAGS`) to embed version, git hash, and build timestamp into the binary.

Build and run commands:

* Added `build` and `run` targets to compile and execute the project with static linking and embedded metadata.
* Added `clean` target to remove build artifacts from the `bin` directory.

Code quality and tooling:

* Added `check` target for running `go vet` and `staticcheck` to enforce code quality.
* Added `tools` target to configure Go proxy and install static analysis tools.