### PR TITLE
fix(singleflight): handle nil response in duplicate request handling #6

### DIFF
--- a/proxy/singleflight/singleflight.go
+++ b/proxy/singleflight/singleflight.go
@@ -183,6 +183,18 @@ func (g *Group) doCall(c *call, key string, fn func() (*http.Response, error)) {
 		} else {
 			// Normal return
 			if c.dups > 0 {
+				// response nil
+				if c.val == nil {
+					for _, ch := range c.chans {
+						ch <- Result{
+							Val:    nil,
+							Err:    c.err,
+							Shared: c.dups > 0,
+						}
+					}
+					return
+				}
+
 				pipes := make([]struct {
 					reader *io.PipeReader
 					writer *io.PipeWriter


### PR DESCRIPTION
This pull request updates the `doCall` method in `proxy/singleflight/singleflight.go` to handle the case where the response value is `nil` when there are duplicate requests. Now, if `c.val` is `nil`, all waiting channels receive a `Result` with a `nil` value and the corresponding error, and the function returns early. This ensures that duplicate requests are properly notified of failure cases.

- Improved duplicate request handling:
  * In `doCall`, added logic to immediately notify all waiting channels with a `Result` containing `nil` for `Val` and the error from `c.err` if the response value is `nil`, ensuring correct error propagation for duplicate requests.