### PR TITLE
WIP feat: in-memory storage

### DIFF
--- a/api/defined/v1/storage/storage.go
+++ b/api/defined/v1/storage/storage.go
@@ -22,7 +22,7 @@ type Operation interface {
 	// Store store the metadata for the specified object ID.
 	Store(ctx context.Context, meta *object.Metadata) error
 	// Exist checks if the object exists.
-	Exist(ctx context.Context, id []byte) bool
+	Exist(ctx context.Context, id object.IDHash) bool
 	// Remove soft-removes the object.
 	Remove(ctx context.Context, id *object.ID) error
 	// Discard hard-removes the object.

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -65,6 +65,7 @@ type Upstream struct {
 type Storage struct {
 	Driver          string    `json:"driver" yaml:"driver"`
 	DBType          string    `json:"db_type" yaml:"db_type"`
+	DBPath          string    `json:"db_path" yaml:"db_path"`
 	AsyncLoad       bool      `json:"async_load" yaml:"async_load"`
 	EvictionPolicy  string    `json:"eviction_policy" yaml:"eviction_policy"`
 	SelectionPolicy string    `json:"selection_policy" yaml:"selection_policy"`
@@ -76,6 +77,7 @@ type Bucket struct {
 	Driver    string `json:"driver" yaml:"driver"`         // native, custom-driver
 	Type      string `json:"type" yaml:"type"`             // normal, cold, hot, fastmemory
 	DBType    string `json:"db_type" yaml:"db_type"`       // boltdb, badgerdb, pebble
+	DBPath    string `json:"db_path" yaml:"db_path"`       // indexdb path, default: <path>/.indexdb/
 	AsyncLoad bool   `json:"async_load" yaml:"async_load"` // load metadata async
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,14 +78,15 @@ plugin:
 storage:
   driver: native # native, custom-driver
   db_type: pebble # boltdb, badgerdb, pebble
+  db_path: .indexdb # index-db path, default: ./.indexdb/
   async_load: true
   eviction_policy: fifo # fifo, lru, lfu
   selection_policy: hashring # hashring, roundrobin
   buckets:
     - path: /cache1
       type: normal
-    - path: /cache2
-      type: normal
+      # db_type: pebble
+      # db_path: inmemory # index-db path, default: <path>/.indexdb/; use "inmemory" for in-memory store
 upstream:
   balancing: wrr
   address:

--- a/server/middleware/caching/processor.go
+++ b/server/middleware/caching/processor.go
@@ -123,7 +123,6 @@ func (pc *ProcessorChain) preCacheProcessor(proxyClient proxy.Proxy, opt *cachin
 		caching.log.Errorf("failed lookup cache err: %v", err)
 	}
 	caching.hit = hit
-
 	return caching, nil
 }
 

--- a/storage/bucket/empty/empty.go
+++ b/storage/bucket/empty/empty.go
@@ -43,7 +43,7 @@ func (e *emptyBucket) DiscardWithMetadata(ctx context.Context, meta *object.Meta
 }
 
 // Exist implements storage.Bucket.
-func (e *emptyBucket) Exist(ctx context.Context, id []byte) bool {
+func (e *emptyBucket) Exist(ctx context.Context, id object.IDHash) bool {
 	return false
 }
 

--- a/storage/bucket/memory/memory.go
+++ b/storage/bucket/memory/memory.go
@@ -2,110 +2,151 @@ package memory
 
 import (
 	"context"
+	"io/fs"
+
+	"github.com/cockroachdb/pebble/v2/vfs"
 
 	"github.com/omalloc/tavern/api/defined/v1/storage"
 	"github.com/omalloc/tavern/api/defined/v1/storage/object"
+	"github.com/omalloc/tavern/conf"
+	"github.com/omalloc/tavern/contrib/log"
+	"github.com/omalloc/tavern/pkg/algorithm/lru"
+	"github.com/omalloc/tavern/storage/indexdb"
 )
 
 var _ storage.Bucket = (*memoryBucket)(nil)
 
-type memoryBucket struct{}
-
-func New() (storage.Bucket, error) {
-	return &memoryBucket{}, nil
+type memoryBucket struct {
+	fs        vfs.FS
+	path      string
+	dbPath    string
+	driver    string
+	storeType string
+	weight    int
+	sharedkv  storage.SharedKV
+	indexdb   storage.IndexDB
+	cache     *lru.Cache[object.IDHash, storage.Mark]
+	fileMode  fs.FileMode
+	maxSize   uint64
+	stop      chan struct{}
 }
 
-func (r *memoryBucket) Close() error {
-	//TODO implement me
-	panic("implement me")
+func New(config *conf.Bucket, sharedkv storage.SharedKV) (storage.Bucket, error) {
+	mb := &memoryBucket{
+		fs:        vfs.NewMem(),
+		path:      config.Path,
+		dbPath:    indexdb.TypeInMemory,
+		driver:    config.Driver,
+		storeType: "memory",
+		weight:    100, // default weight
+		sharedkv:  sharedkv,
+		cache:     lru.New[object.IDHash, storage.Mark](10_000), // in-memory object size
+		fileMode:  fs.FileMode(0o755),
+		maxSize:   1024 * 1024 * 100, // e.g. 100 MB
+		stop:      make(chan struct{}, 1),
+	}
+
+	// create indexdb only in-memory
+	db, err := indexdb.Create(config.DBType, indexdb.NewOption(mb.dbPath, indexdb.WithType("pebble")))
+	if err != nil {
+		log.Errorf("failed to create %s indexdb %v", config.DBType, err)
+		return nil, err
+	}
+	mb.indexdb = db
+	return mb, nil
 }
 
-func (r *memoryBucket) Lookup(ctx context.Context, id *object.ID) (*object.Metadata, error) {
-	//TODO implement me
-	panic("implement me")
+// Allow implements [storage.Bucket].
+func (m *memoryBucket) Allow() int {
+	return int(m.maxSize)
 }
 
-func (r *memoryBucket) Store(ctx context.Context, meta *object.Metadata) error {
-	//TODO implement me
-	panic("implement me")
+// Close implements [storage.Bucket].
+func (m *memoryBucket) Close() error {
+	return m.indexdb.Close()
 }
 
-func (r *memoryBucket) Exist(ctx context.Context, id []byte) bool {
-	//TODO implement me
-	panic("implement me")
+// Discard implements [storage.Bucket].
+func (m *memoryBucket) Discard(ctx context.Context, id *object.ID) error {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) Remove(ctx context.Context, id *object.ID) error {
-	//TODO implement me
-	panic("implement me")
+// DiscardWithHash implements [storage.Bucket].
+func (m *memoryBucket) DiscardWithHash(ctx context.Context, hash object.IDHash) error {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) Discard(ctx context.Context, id *object.ID) error {
-	//TODO implement me
-	panic("implement me")
+// DiscardWithMessage implements [storage.Bucket].
+func (m *memoryBucket) DiscardWithMessage(ctx context.Context, id *object.ID, msg string) error {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) DiscardWithHash(ctx context.Context, hash object.IDHash) error {
-	//TODO implement me
-	panic("implement me")
+// DiscardWithMetadata implements [storage.Bucket].
+func (m *memoryBucket) DiscardWithMetadata(ctx context.Context, meta *object.Metadata) error {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) DiscardWithMessage(ctx context.Context, id *object.ID, msg string) error {
-	//TODO implement me
-	panic("implement me")
+// Exist implements [storage.Bucket].
+func (m *memoryBucket) Exist(ctx context.Context, id object.IDHash) bool {
+	return m.cache.Has(id)
 }
 
-func (r *memoryBucket) DiscardWithMetadata(ctx context.Context, meta *object.Metadata) error {
-	//TODO implement me
-	panic("implement me")
+// Expired implements [storage.Bucket].
+func (m *memoryBucket) Expired(ctx context.Context, id *object.ID, md *object.Metadata) bool {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) Iterate(ctx context.Context, fn func(*object.Metadata) error) error {
-	//TODO implement me
-	panic("implement me")
+// HasBad implements [storage.Bucket].
+func (m *memoryBucket) HasBad() bool {
+	return false
 }
 
-func (r *memoryBucket) Expired(ctx context.Context, id *object.ID, md *object.Metadata) bool {
-	//TODO implement me
-	panic("implement me")
+// ID implements [storage.Bucket].
+func (m *memoryBucket) ID() string {
+	return m.path
 }
 
-func (r *memoryBucket) ID() string {
-	//TODO implement me
-	panic("implement me")
+// Iterate implements [storage.Bucket].
+func (m *memoryBucket) Iterate(ctx context.Context, fn func(*object.Metadata) error) error {
+	panic("unimplemented")
 }
 
-func (r *memoryBucket) Weight() int {
-	//TODO implement me
-	panic("implement me")
+// Lookup implements [storage.Bucket].
+func (m *memoryBucket) Lookup(ctx context.Context, id *object.ID) (*object.Metadata, error) {
+	return nil, storage.ErrKeyNotFound
 }
 
-func (r *memoryBucket) Allow() int {
-	//TODO implement me
-	panic("implement me")
+// Path implements [storage.Bucket].
+func (m *memoryBucket) Path() string {
+	return m.path
 }
 
-func (r *memoryBucket) UseAllow() bool {
-	//TODO implement me
-	panic("implement me")
+// Remove implements [storage.Bucket].
+func (m *memoryBucket) Remove(ctx context.Context, id *object.ID) error {
+	return nil
 }
 
-func (r *memoryBucket) HasBad() bool {
-	//TODO implement me
-	panic("implement me")
+// Store implements [storage.Bucket].
+func (m *memoryBucket) Store(ctx context.Context, meta *object.Metadata) error {
+	return nil
 }
 
-func (r *memoryBucket) Type() string {
-	//TODO implement me
-	panic("implement me")
+// StoreType implements [storage.Bucket].
+func (m *memoryBucket) StoreType() string {
+	return m.storeType
 }
 
-func (r *memoryBucket) StoreType() string {
-	//TODO implement me
-	panic("implement me")
+// Type implements [storage.Bucket].
+func (m *memoryBucket) Type() string {
+	return m.driver
 }
 
-func (r *memoryBucket) Path() string {
-	//TODO implement me
-	panic("implement me")
+// UseAllow implements [storage.Bucket].
+func (m *memoryBucket) UseAllow() bool {
+	return true
+}
+
+// Weight implements [storage.Bucket].
+func (m *memoryBucket) Weight() int {
+	return m.weight
 }

--- a/storage/builder.go
+++ b/storage/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omalloc/tavern/conf"
 	"github.com/omalloc/tavern/storage/bucket/disk"
 	"github.com/omalloc/tavern/storage/bucket/empty"
+	"github.com/omalloc/tavern/storage/bucket/memory"
 	_ "github.com/omalloc/tavern/storage/indexdb/pebble"
 )
 
@@ -16,12 +17,14 @@ type globalBucketOption struct {
 	SelectionPolicy string
 	Driver          string
 	DBType          string
+	DBPath          string
 }
 
 // implements storage.Bucket map.
 var bucketMap = map[string]func(opt *conf.Bucket, sharedkv storage.SharedKV) (storage.Bucket, error){
 	"empty":  empty.New,
 	"native": disk.New, // disk is an alias of native
+	"memory": memory.New,
 }
 
 func NewBucket(opt *conf.Bucket, sharedkv storage.SharedKV) (storage.Bucket, error) {
@@ -40,6 +43,7 @@ func mergeConfig(global *globalBucketOption, bucket *conf.Bucket) *conf.Bucket {
 		Driver: bucket.Driver,
 		Type:   bucket.Type,
 		DBType: bucket.DBType,
+		DBPath: bucket.DBPath,
 	}
 
 	if copied.Driver == "" {
@@ -50,6 +54,9 @@ func mergeConfig(global *globalBucketOption, bucket *conf.Bucket) *conf.Bucket {
 	}
 	if copied.DBType == "" {
 		copied.DBType = global.DBType
+	}
+	if copied.DBPath == "" {
+		copied.DBPath = global.DBPath
 	}
 	return copied
 }

--- a/storage/indexdb/indexdb.go
+++ b/storage/indexdb/indexdb.go
@@ -6,6 +6,8 @@ import (
 	"github.com/omalloc/tavern/pkg/mapstruct"
 )
 
+const TypeInMemory = "inmemory"
+
 var defaultRegistry = NewRegistry()
 
 type option struct {


### PR DESCRIPTION
This pull request introduces significant improvements to the storage subsystem, focusing on enhanced configuration flexibility, better in-memory storage support, and consistent interface usage. The main changes include adding explicit support for in-memory buckets, unifying the way storage paths are configured, and updating interfaces and implementations for improved type safety and maintainability.

**Key changes:**

### In-Memory Storage Support

* Added a new `memory` bucket type with its own implementation (`memoryBucket`), supporting in-memory object storage with a dedicated LRU cache and indexdb, and ensured only one memory bucket can be used at a time. (`storage/bucket/memory/memory.go`, `storage/builder.go`, `storage/storage.go`) [[1]](diffhunk://#diff-7a6975d9993a71216a975624780aa8de6b0a2033ee02ae06bcc89c069ff73438R5-R151) [[2]](diffhunk://#diff-ff9c167f1308d28cb3dcd95594e7261fe897827760672ca2bc7a0f5270c09384R10) [[3]](diffhunk://#diff-ff9c167f1308d28cb3dcd95594e7261fe897827760672ca2bc7a0f5270c09384R20-R27) [[4]](diffhunk://#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62ddeL29-R29) [[5]](diffhunk://#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62ddeL44-R44) [[6]](diffhunk://#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62ddeR70-R91) [[7]](diffhunk://#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62ddeR107-R115) [[8]](diffhunk://#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62ddeL153-R170)

* Updated the pebble indexdb backend to support in-memory mode by using a memory-backed filesystem when the `db_path` is set to `"inmemory"`. (`storage/indexdb/pebble/pebble.go`, `storage/indexdb/indexdb.go`) [[1]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948L6-R8) [[2]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948R121-L135) [[3]](diffhunk://#diff-3abacddb8a5a0e206026737bdf95c70216424caf24303181edc64df93ab8e35aR9-R10)

### Configuration Enhancements

* Introduced a new `db_path` field in both global storage and per-bucket configurations, allowing explicit control over indexdb storage paths, including support for in-memory stores. (`conf/conf.go`, `config.example.yaml`, `storage/builder.go`) [[1]](diffhunk://#diff-5cf7ec6473e39de420f278cec18ee6ac7f9e911dd74a009c9fa70095b2379637R68) [[2]](diffhunk://#diff-5cf7ec6473e39de420f278cec18ee6ac7f9e911dd74a009c9fa70095b2379637R80) [[3]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aR81-R89) [[4]](diffhunk://#diff-ff9c167f1308d28cb3dcd95594e7261fe897827760672ca2bc7a0f5270c09384R46) [[5]](diffhunk://#diff-ff9c167f1308d28cb3dcd95594e7261fe897827760672ca2bc7a0f5270c09384R58-R60)

* Updated the disk bucket to use the configurable `db_path`, defaulting to the previous behavior if not specified. (`storage/bucket/disk/disk.go`)

### Interface Consistency and Type Safety

* Changed the `Exist` method signatures in storage interfaces and implementations to use the `object.IDHash` type instead of raw `[]byte`, improving type safety and consistency across buckets. (`api/defined/v1/storage/storage.go`, `storage/bucket/disk/disk.go`, `storage/bucket/empty/empty.go`, `storage/bucket/memory/memory.go`) [[1]](diffhunk://#diff-a31283644bc432c5a085337b9fe1c93dac777e29d75e1029f65d264f912ed238L25-R25) [[2]](diffhunk://#diff-4e71340b5335ca4d00c67541fb3986fadcb940512113eca2a4f08bbf89af3077L240-R243) [[3]](diffhunk://#diff-0983f82d13144088a53882a604c0b03e5b5e3926813af40c2ced90c754b5b482L46-R46) [[4]](diffhunk://#diff-7a6975d9993a71216a975624780aa8de6b0a2033ee02ae06bcc89c069ff73438R5-R151)

### Performance Tuning

* Increased the default LRU cache size for disk buckets from 100,000 to 1,000,000 entries to improve performance. (`storage/bucket/disk/disk.go`)

These changes collectively provide more flexible and robust storage configuration, improved in-memory caching capabilities, and a cleaner, safer codebase for storage operations.