### PR TITLE
fix(caching): closer conn check if the request is Chunked and EOF drop cache

### DIFF
--- a/tests/mockserver/main.go
+++ b/tests/mockserver/main.go
@@ -80,6 +80,11 @@ func main() {
 		http.ServeFile(w, r, "./files/1M.bin")
 	})))
 
+	mux.Handle("/chunked", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reader := iobuf.NewRateLimitReader(io.NopCloser(bytes.NewReader(buf)), 200)
+		_, _ = io.Copy(w, reader)
+	}))
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("received request: %s %s", r.Method, r.URL.String())
 


### PR DESCRIPTION
This pull request introduces improvements to the caching logic and expands the mock server's test endpoints. The most significant changes are related to better handling of incomplete chunked uploads and the addition of a new endpoint for testing chunked responses.

**Caching logic improvements:**

* Updated the `flushbufferSlice` function in `caching.go` to discard incomplete chunked file uploads by calling `DiscardWithMessage` if the end of file (`eof`) is not reached and the response is chunked. This helps prevent storing incomplete or corrupted cache entries.

**Testing enhancements:**

* Added a `/chunked` endpoint to the mock server in `main.go` that serves data using a rate-limited reader, enabling more robust testing of chunked transfer encoding scenarios.