### PR TITLE
feat(purge): add Prometheus metrics for purge request tracking

### DIFF
--- a/plugin/purge/metrics.go
+++ b/plugin/purge/metrics.go
@@ -1,0 +1,22 @@
+package purge
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	_metricPurgeRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tr",
+		Subsystem: "tavern",
+		Name:      "purge_requests_total",
+		Help:      "Total number of purge requests",
+	}, []string{"code"})
+)
+
+func init() {
+	prometheus.MustRegister(_metricPurgeRequestsTotal)
+
+	// docs/purge.md references these labels
+	_metricPurgeRequestsTotal.WithLabelValues("200")
+	_metricPurgeRequestsTotal.WithLabelValues("403")
+	_metricPurgeRequestsTotal.WithLabelValues("404")
+	_metricPurgeRequestsTotal.WithLabelValues("500")
+}


### PR DESCRIPTION
This pull request adds Prometheus metrics tracking to the purge plugin and improves the `/plugin/purge/tasks` endpoint to return the current purge task list in JSON format. The most important changes are grouped below.

**Metrics and Observability:**

* Introduced a new Prometheus counter metric `_metricPurgeRequestsTotal` in `metrics.go` to track the total number of purge requests, labeled by response code (200, 403, 404, 500). This metric is incremented at appropriate points in the purge handler to reflect request outcomes. [[1]](diffhunk://#diff-cd81bc12f794a36d36ae67e7833404fdfe0ee1bd8730b3c83fb972a60755ed25R1-R22) [[2]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R93) [[3]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R105) [[4]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R121) [[5]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R130-R136) [[6]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R145) [[7]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R156-R163) [[8]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R172)

**API Improvements:**

* Enhanced the `/plugin/purge/tasks` endpoint to query the shared key-value store for purge tasks, aggregate them into a map, and return the results as a JSON response using the default codec.

**Codebase Maintenance:**

* Added new imports for `encoding/binary` and the internal `encoding` package to support the updated endpoint logic. [[1]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R5) [[2]](diffhunk://#diff-debc48aaf7a841de58b4079f46ff8026796372dac581ed80fd18160ea3c0ab96R17)