### PR TITLE
fix: caching middleware's partRequest getUpstreamReader range request…

### DIFF
--- a/server/middleware/caching/internal.go
+++ b/server/middleware/caching/internal.go
@@ -197,10 +197,8 @@ func getContents(c *Caching, reqChunks []uint32, from uint32) (io.ReadCloser, in
 
 			// Identify an anchor block and synchronize any missing blocks prior to the current index.
 			toByte := min(c.md.Size-1, uint64(availableChunks[index]*uint32(partSize))-1)
-			req := c.req.Clone(context.Background())
-			newRange := fmt.Sprintf("bytes=%d-%d", fromByte, toByte)
-			req.Header.Set("Range", newRange)
 
+			// Request is automatically cloned by getUpstreamReader
 			reader, err := c.getUpstreamReader(fromByte, toByte, true)
 			if err != nil {
 				return nil, 0, err
@@ -218,10 +216,8 @@ func getContents(c *Caching, reqChunks []uint32, from uint32) (io.ReadCloser, in
 		tailChunkSize = uint64(rng.End)
 	}
 	toByte := min(c.md.Size-1, tailChunkSize)
-	newRange := fmt.Sprintf("bytes=%d-%d", fromByte, toByte)
-	req := c.req.Clone(context.Background())
-	req.Header.Set("Range", newRange)
 
+	// Request is automatically cloned by getUpstreamReader
 	reader, err := c.getUpstreamReader(fromByte, toByte, true)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
This pull request simplifies the logic in the `getContents` function by removing manual HTTP request cloning and range header setting, instead delegating these responsibilities to the `getUpstreamReader` method.

Refactoring and simplification:

* Removed manual cloning of `c.req` and manual setting of the `Range` header in favor of using `getUpstreamReader`, which now handles copying the request and setting the appropriate headers. (`server/middleware/caching/internal.go`) [[1]](diffhunk://#diff-8a1e239d89e1cf8de069c991dc73ff3c90d7e79312012282a8c557a0997f58b4L200-R201) [[2]](diffhunk://#diff-8a1e239d89e1cf8de069c991dc73ff3c90d7e79312012282a8c557a0997f58b4L221-R220)