### PR TITLE
feat: Introduce flag constants and enable conditional caching of erro…

### DIFF
--- a/internal/constants/global.go
+++ b/internal/constants/global.go
@@ -16,3 +16,9 @@ const (
 	InternalCacheErrCode     = "i-x-ct-code"
 	InternalUpstreamAddr     = "i-x-ups-addr"
 )
+
+// define flag constants
+const (
+	FlagOn  = "1" // gateway control flag ON
+	FlagOff = "0" // gateway control flag OFF
+)


### PR DESCRIPTION
This pull request introduces a new mechanism for controlling error code caching behavior in the gateway by defining explicit flag constants and updating the error code caching logic to use these flags. The main focus is to make the enabling or disabling of error code caching more explicit and maintainable.

Key changes include:

#### Gateway control flags

* Added new flag constants `FlagOn` and `FlagOff` in `internal/constants/global.go` to explicitly represent gateway control states for features such as error code caching.

#### Error code caching logic

* Updated the error code caching logic in `server/middleware/caching/caching.go` to use the new `FlagOn` constant for checking if error code caching is enabled, improving clarity and making the feature toggle more maintainable. The logic now also allows error responses to be cached if the header is set to `FlagOn`, and suppresses proxy errors in that scenario.