### PR TITLE
docs: Mark "Hot migration" and "Warm/cold split" as completed in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Other languages: [简体中文](README.zh-CN.md)
   - [x] Fuzzy refresh (Fuzzing fetch)
   - [x] Auto refresh
   - [x] Cache validation
-  - [ ] Hot migration
-  - [ ] Warm/cold split
+  - [x] Hot migration
+  - [x] Warm/cold split
   - [x] Upstream collapse request (request coalescing)
   - [ ] ~~Image compression adaptation (WebP support)~~
   - [x] Vary-based versioned cache (Vary cache)
@@ -53,7 +53,6 @@ Other languages: [简体中文](README.zh-CN.md)
 ## Ecosystem
 
 - Cache CRC verification service: [CRC-Center](https://github.com/omalloc/trust-receive)
-
 
 ## 🚀 Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,8 +30,8 @@ Tavern 是一个 Go 实现的高性能 HTTP 缓存代理服务器，旨在利用
   - [x] 模糊刷新 (Fuzzing fetch)
   - [x] 自动刷新 (Auto Refresh)
   - [x] 缓存变更校验 (Cache Validation)
-  - [ ] 热点迁移 (Hot Migration)
-  - [ ] 冷热分离 (Warm Cold Split)
+  - [x] 热点迁移 (Hot Migration)
+  - [x] 冷热分离 (Warm Cold Split)
   - [x] 上游请求合并 (Upstream Collapse Request)
   - [ ] ~~图像压缩自适应 (Webp Support)~~
   - [x] Vary 分版本缓存 (Vary Cache)
@@ -53,7 +53,6 @@ Tavern 是一个 Go 实现的高性能 HTTP 缓存代理服务器，旨在利用
 ## 生态环境
 
 - 缓存校验服务: [缓存校验中心](https://github.com/omalloc/trust-receive)
-
 
 ## 🚀 快速开始 (Quick Start)
 


### PR DESCRIPTION
This pull request updates the documentation to reflect that the "Hot migration" and "Warm/cold split" features are now implemented. The checklists in both the English and Simplified Chinese `README` files have been updated to mark these features as complete.

Feature status updates in documentation:

* Marked "Hot migration" and "Warm/cold split" as completed in the feature checklist in `README.md`
* Marked "热点迁移 (Hot Migration)" and "冷热分离 (Warm Cold Split)" as completed in the feature checklist in `README.zh-CN.md`
