### PR TITLE
fix: PebbleDB and noneSharedKV Close idempotent using `sync.Once`.

### DIFF
--- a/storage/indexdb/pebble/pebble.go
+++ b/storage/indexdb/pebble/pebble.go
@@ -3,6 +3,7 @@ package pebble
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -22,6 +23,7 @@ type PebbleDB struct {
 	db            *pebble.DB
 	writeMode     *pebble.WriteOptions
 	skipErrRecord bool
+	closed        sync.Once
 }
 
 func init() {
@@ -112,9 +114,13 @@ func (p *PebbleDB) Expired(ctx context.Context, f storage.IterateFunc) error {
 
 // Close implements storage.IndexDB.
 func (p *PebbleDB) Close() error {
-	// force flush data to disk
-	_ = p.db.Flush()
-	return p.db.Close()
+	var err error
+	p.closed.Do(func() {
+		_ = p.db.Flush()
+		// force flush data to disk
+		err = p.db.Close()
+	})
+	return err
 }
 
 // GC implements storage.IndexDB.
@@ -178,5 +184,6 @@ func New(path string, option storage.Option) (storage.IndexDB, error) {
 		db:            pdb,
 		writeMode:     writeMode, // 是否异步写操作
 		skipErrRecord: true,
+		closed:        sync.Once{},
 	}, nil
 }

--- a/storage/sharedkv/nonekv.go
+++ b/storage/sharedkv/nonekv.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"sync"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/omalloc/tavern/api/defined/v1/storage"
@@ -12,11 +13,16 @@ import (
 var _ storage.SharedKV = (*noneSharedKV)(nil)
 
 type noneSharedKV struct {
-	db *pebble.DB
+	db     *pebble.DB
+	closed sync.Once
 }
 
 func (r *noneSharedKV) Close() error {
-	return r.db.Close()
+	var err error
+	r.closed.Do(func() {
+		err = r.db.Close()
+	})
+	return err
 }
 
 func (r *noneSharedKV) Get(_ context.Context, key []byte) ([]byte, error) {
@@ -189,7 +195,8 @@ func newNoneKV(storePath string, opts *pebble.Options) (storage.SharedKV, error)
 	}
 
 	r := &noneSharedKV{
-		db: db,
+		db:     db,
+		closed: sync.Once{},
 	}
 	return r, nil
 }


### PR DESCRIPTION
This pull request introduces a thread-safe mechanism to ensure that the `Close()` method for both the `PebbleDB` and `noneSharedKV` storage implementations is executed only once, even if called multiple times. This prevents potential issues such as double-closing the underlying database, which could lead to panics or resource leaks.

Thread safety and resource management improvements:

* Added a `sync.Once` field named `closed` to both the `PebbleDB` and `noneSharedKV` structs to guarantee that the `Close()` operation is performed only once, regardless of how many times `Close()` is called. [[1]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948R26) [[2]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948R187) [[3]](diffhunk://#diff-823b5af8982debaec4059b7e5f41b423ca662a4906dd97afbf0b4c5fd433e288R17-R25) [[4]](diffhunk://#diff-823b5af8982debaec4059b7e5f41b423ca662a4906dd97afbf0b4c5fd433e288R199)
* Updated the `Close()` methods in both `pebble.go` and `nonekv.go` to use the `sync.Once` field, ensuring thread safety and preventing multiple close attempts on the same database instance. [[1]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948L115-R123) [[2]](diffhunk://#diff-823b5af8982debaec4059b7e5f41b423ca662a4906dd97afbf0b4c5fd433e288R17-R25)
* Added the necessary import for the `sync` package in both files to support the new thread-safe logic. [[1]](diffhunk://#diff-ded24b15d27e6210544b058dce1aef94b4760412185b6c43ad61ea067e6c3948R6) [[2]](diffhunk://#diff-823b5af8982debaec4059b7e5f41b423ca662a4906dd97afbf0b4c5fd433e288R7)